### PR TITLE
fix: add SaltWindowExceptionHandler to prevent duplicate AWT exception reports

### DIFF
--- a/ui2/src/desktopMain/kotlin/com/moriafly/salt/ui/window/internal/SaltWindowExceptionHandler.kt
+++ b/ui2/src/desktopMain/kotlin/com/moriafly/salt/ui/window/internal/SaltWindowExceptionHandler.kt
@@ -17,17 +17,22 @@
 
 package com.moriafly.salt.ui.window.internal
 
-import androidx.compose.ui.ExperimentalComposeUiApi
-import androidx.compose.ui.window.WindowExceptionHandler
-import androidx.compose.ui.window.WindowExceptionHandlerFactory
 import com.moriafly.salt.ui.UnstableSaltUiApi
-import java.awt.Window
 
+/**
+ * Handler for exceptions caught inside [com.moriafly.salt.ui.window.SaltWindow]
+ * and [com.moriafly.salt.ui.window.SaltDialogWindow].
+ *
+ * By default the exception is rethrown. The caller application can override
+ * [onException] to redirect exceptions to its own logging or crash-reporting
+ * system. When overridden, the exception is considered handled and will not be
+ * propagated to the AWT event loop.
+ */
 @UnstableSaltUiApi
-@ExperimentalComposeUiApi
-internal object SaltWindowExceptionHandlerFactory : WindowExceptionHandlerFactory {
-    override fun exceptionHandler(window: Window): WindowExceptionHandler =
-        WindowExceptionHandler { throwable ->
-            SaltWindowExceptionHandler.onException(throwable)
-        }
+object SaltWindowExceptionHandler {
+    /**
+     * Called synchronously on the UI thread (AWT Event Dispatch Thread)
+     * when an uncaught exception occurs inside a Salt window.
+     */
+    var onException: (Throwable) -> Unit = { throw it }
 }


### PR DESCRIPTION
When an uncaught exception is thrown inside a SaltWindow (e.g. from an onClick lambda), the old WindowExceptionHandler simply re-threw it. This caused AWT's Component.dispatchEventImpl and EventQueue.dispatchEventImpl to catch the same throwable separately, invoking the global UncaughtExceptionHandler twice and producing duplicated crash logs/dialogs.

SaltWindowExceptionHandler now provides an optional, overridable callback. Host applications can set onException to consume the error themselves, which stops the duplicate propagation. The default behavior remains
	hrow it so existing apps are not broken.