### PR TITLE
feat(Linux): add Linux distribution info retrieval

### DIFF
--- a/core/src/commonMain/kotlin/com/moriafly/salt/core/os/OS.kt
+++ b/core/src/commonMain/kotlin/com/moriafly/salt/core/os/OS.kt
@@ -95,7 +95,16 @@ sealed class OS {
         val build: String
     ) : OS()
 
-    object Linux : OS()
+    /**
+     * Linux platform.
+     *
+     * @property version Linux kernel version string (e.g., "5.15.0-78-generic")
+     * @property distro Optional Linux distribution name (e.g., "Ubuntu 22.04"), empty if unavailable
+     */
+    data class Linux(
+        val version: String,
+        val distro: String
+    ) : OS()
 
     object IOS : OS()
 

--- a/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/OS.desktop.kt
+++ b/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/OS.desktop.kt
@@ -15,6 +15,7 @@
 
 package com.moriafly.salt.core.os
 
+import com.moriafly.salt.core.os.linux.LinuxDistributionInfo
 import com.moriafly.salt.core.os.macos.MacOSVersionInfo
 import com.sun.jna.platform.win32.Kernel32
 import com.sun.jna.platform.win32.WinNT
@@ -37,8 +38,12 @@ actual fun os(): OS {
             OS.Windows(osVersionInfoEx.buildNumber)
         }
 
-        osName == "Linux" -> OS.Linux
-
+        osName == "Linux" -> {
+            OS.Linux(
+                version = System.getProperty("os.version"),
+                distro = LinuxDistributionInfo.getDistributionInfo()
+            )
+        }
         else -> throw Error("Unknown Desktop OS $osName")
     }
 }

--- a/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/linux/LinuxDistributionInfo.kt
+++ b/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/linux/LinuxDistributionInfo.kt
@@ -1,3 +1,18 @@
+/*
+ * Salt UI
+ * Copyright (C) 2026 Moriafly
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ */
+
 package com.moriafly.salt.core.os.linux
 
 import java.io.File
@@ -5,7 +20,7 @@ import java.io.File
 internal object LinuxDistributionInfo {
     fun getDistributionInfo(): String = readFromOsRelease().ifEmpty { readFromLsbRelease() }
 
-    internal fun readFromOsRelease(): String = runCatching {
+    private fun readFromOsRelease(): String = runCatching {
         val content = File("/etc/os-release").readText()
         val regex = "PRETTY_NAME=\"([^\"]+)\"".toRegex()
         regex.find(content)?.groupValues?.get(1).orEmpty()
@@ -13,7 +28,7 @@ internal object LinuxDistributionInfo {
         .getOrNull()
         .orEmpty()
 
-    internal fun readFromLsbRelease(): String = runCatching {
+    private fun readFromLsbRelease(): String = runCatching {
         val content = File("/etc/lsb-release").readText()
         val regex = "DISTRIB_DESCRIPTION=\"([^\"]+)\"".toRegex()
         regex.find(content)?.groupValues?.get(1).orEmpty()

--- a/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/linux/LinuxDistributionInfo.kt
+++ b/core/src/desktopMain/kotlin/com/moriafly/salt/core/os/linux/LinuxDistributionInfo.kt
@@ -1,0 +1,23 @@
+package com.moriafly.salt.core.os.linux
+
+import java.io.File
+
+internal object LinuxDistributionInfo {
+    fun getDistributionInfo(): String = readFromOsRelease().ifEmpty { readFromLsbRelease() }
+
+    internal fun readFromOsRelease(): String = runCatching {
+        val content = File("/etc/os-release").readText()
+        val regex = "PRETTY_NAME=\"([^\"]+)\"".toRegex()
+        regex.find(content)?.groupValues?.get(1).orEmpty()
+    }
+        .getOrNull()
+        .orEmpty()
+
+    internal fun readFromLsbRelease(): String = runCatching {
+        val content = File("/etc/lsb-release").readText()
+        val regex = "DISTRIB_DESCRIPTION=\"([^\"]+)\"".toRegex()
+        regex.find(content)?.groupValues?.get(1).orEmpty()
+    }
+        .getOrNull()
+        .orEmpty()
+}


### PR DESCRIPTION
- Change OS.Linux to data class from object
- Add build property to OS.Linux data class
- Implement LinuxDistributionInfo with dual fallback strategy:
  1. Read from /etc/os-release
  2. Fallback to read from /etc/lsb-release if os-release fails